### PR TITLE
 Add Focal (postgres 12) support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     name: build ${{ matrix.base-image }}
     strategy:
       matrix:
-        base-image: [xenial]
+        base-image: [xenial, focal]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -1,0 +1,107 @@
+ARG nominatim_version=3.5.2
+
+FROM ubuntu:focal as builder
+
+ARG nominatim_version
+
+# Let the container know that there is no TTY
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install packages
+RUN apt-get -y update \
+ && apt-get install -y -qq --no-install-recommends \
+    build-essential \
+    cmake \
+    g++ \
+    libboost-dev \
+    libboost-filesystem1.71-dev \
+    libexpat1-dev \
+    zlib1g-dev \
+    libxml2-dev \
+    libbz2-dev \
+    libpq-dev \
+    libgeos-dev \
+    libgeos++-dev \
+    libproj-dev \
+    postgresql-server-dev-12 \
+    php \
+    curl
+
+# Build Nominatim
+RUN cd /srv \
+ && curl --silent -L http://www.nominatim.org/release/Nominatim-${nominatim_version}.tar.bz2 -o v${nominatim_version}.tar.bz2 \
+ && tar xf v${nominatim_version}.tar.bz2 \
+ && rm v${nominatim_version}.tar.bz2 \
+ && mv Nominatim-${nominatim_version} nominatim \
+ && cd nominatim \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make
+
+
+FROM ubuntu:focal
+
+ARG nominatim_version
+
+LABEL \
+  maintainer="Peter Evans <mail@peterevans.dev>" \
+  org.opencontainers.image.title="nominatim" \
+  org.opencontainers.image.description="Docker image for Nominatim." \
+  org.opencontainers.image.authors="Peter Evans <mail@peterevans.dev>" \
+  org.opencontainers.image.url="https://github.com/peter-evans/nominatim-docker" \
+  org.opencontainers.image.vendor="https://peterevans.dev" \
+  org.opencontainers.image.licenses="MIT" \
+  app.tag="nominatim${nominatim_version}"
+
+# Let the container know that there is no TTY
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Set locale and install packages
+ENV LANG C.UTF-8
+RUN apt-get -y update \
+ && apt-get install -y -qq --no-install-recommends locales \
+ && locale-gen en_US.UTF-8 \
+ && update-locale LANG=en_US.UTF-8 \
+ && apt-get install -y -qq --no-install-recommends \
+    postgresql-server-dev-12 \
+    postgresql-12-postgis-3 \
+    postgresql-12-postgis-3-scripts \
+    postgresql-contrib-12 \
+    apache2 \
+    php \
+    php-pgsql \
+    libapache2-mod-php \
+    php-pear \
+    php-db \
+    php-intl \
+    python3-dev \
+    python3-psycopg2 \
+    curl \
+    ca-certificates \
+    libboost-filesystem1.71-dev \
+    sudo \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /tmp/* /var/tmp/*
+
+# Copy the application from the builder image
+COPY --from=builder /srv/nominatim /srv/nominatim
+
+# Configure Nominatim
+COPY local.php /srv/nominatim/build/settings/local.php
+
+# Configure Apache
+COPY nominatim.conf /etc/apache2/sites-enabled/000-default.conf
+
+# Allow remote connections to PostgreSQL
+RUN echo "host all  all    0.0.0.0/0  trust" >> /etc/postgresql/12/main/pg_hba.conf \
+ && echo "listen_addresses='*'" >> /etc/postgresql/12/main/postgresql.conf
+
+# Set the entrypoint
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 5432
+EXPOSE 8080

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -79,7 +79,8 @@ RUN apt-get -y update \
     python3-psycopg2 \
     curl \
     ca-certificates \
-    libboost-filesystem1.71-dev \
+    libboost-system1.71\
+    libboost-filesystem1.71 \
     sudo \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \

--- a/focal/docker-entrypoint.sh
+++ b/focal/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Defaults
+NOMINATIM_DATA_PATH=${NOMINATIM_DATA_PATH:="/srv/nominatim/data"}
+NOMINATIM_DATA_LABEL=${NOMINATIM_DATA_LABEL:="data"}
+NOMINATIM_PBF_URL=${NOMINATIM_PBF_URL:="http://download.geofabrik.de/asia/maldives-latest.osm.pbf"}
+
+
+# Retrieve the PBF file
+curl -L $NOMINATIM_PBF_URL --create-dirs -o $NOMINATIM_DATA_PATH/$NOMINATIM_DATA_LABEL.osm.pbf
+# Allow user accounts read access to the data
+chmod 755 $NOMINATIM_DATA_PATH
+
+# Start PostgreSQL
+service postgresql start
+
+# Import data
+sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='nominatim'" | grep -q 1 || sudo -u postgres createuser -s nominatim
+sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data
+sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim"
+useradd -m -p password1234 nominatim
+sudo -u nominatim /srv/nominatim/build/utils/setup.php --osm-file $NOMINATIM_DATA_PATH/$NOMINATIM_DATA_LABEL.osm.pbf --all --threads 2
+
+
+# Tail Apache logs
+tail -f /var/log/apache2/* &
+
+# Run Apache in the foreground
+/usr/sbin/apache2ctl -D FOREGROUND

--- a/focal/local.php
+++ b/focal/local.php
@@ -1,0 +1,7 @@
+<?php
+ // Paths
+ @define('CONST_Postgresql_Version', '9.5');
+ @define('CONST_Postgis_Version', '2.2');
+ // Website settings
+ @define('CONST_Website_BaseURL', '/');
+?>

--- a/focal/local.php
+++ b/focal/local.php
@@ -1,7 +1,7 @@
 <?php
  // Paths
- @define('CONST_Postgresql_Version', '9.5');
- @define('CONST_Postgis_Version', '2.2');
+ @define('CONST_Postgresql_Version', '12');
+ @define('CONST_Postgis_Version', '3');
  // Website settings
  @define('CONST_Website_BaseURL', '/');
 ?>

--- a/focal/nominatim.conf
+++ b/focal/nominatim.conf
@@ -1,0 +1,13 @@
+Listen 8080
+<VirtualHost *:8080>
+        DocumentRoot /srv/nominatim/build/website
+        CustomLog /var/log/apache2/access.log combined
+        ErrorLog /var/log/apache2/error.log
+        LogLevel warn
+        <Directory /srv/nominatim/build/website>
+                Options FollowSymLinks MultiViews
+                DirectoryIndex search.php
+                Require all granted
+        </Directory>
+        AddType text/html .php
+</VirtualHost>


### PR DESCRIPTION
Why do we need this change?
=======================
Currently the docker builds only support one version of postgres which is 9.5 and both ubuntu xenial and postgres 9.5 are both getting close to their end of life timeperiods. As such this will ensure that folks have a path forward to upgrading to newer versions.

What effects does this change have?
=======================
* Adds focal folder for building the ubuntu bionic release for postgres 12 and postgis 3
* Adds focal folder build to the ci.yml to ensure we build both versions.